### PR TITLE
Fix default value of programs.bibtex.target

### DIFF
--- a/llmk.lua
+++ b/llmk.lua
@@ -87,8 +87,8 @@ M.program_spec = {
 
 M.default_programs = {
   bibtex = {
-    target = '%B.bib',
-    args = {'%B'}, -- "%B.bib" will result in an error
+    target = '%B.aux',
+    args = {'%B'},
     postprocess = 'latex',
   },
   dvipdf = {


### PR DESCRIPTION
Fix #9.

This PR also deletes the comment `"%B.bib" will result in an error"`.
`bibtex` expects a basename of `%B.aux` (not that of `%B.bib`) in its command-line arguments.