### PR TITLE
Add support for makeglossaries command

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The following is the list of available TOML keys in llmk. See the reference manu
 * `latex` (type: *string*, default: `"lualatex"`)
 * `llmk_version` (type: *string*)
 * `makeindex` (type: *string*, default: `"makeindex"`)
+* `makeglossaries` (type: *string*, default: `"makeglossaries"`)
 * `max_repeat` (type: *integer*, default: `5`)
 * `programs` (type: *table*)
 	* \<program name\>
@@ -182,7 +183,7 @@ The following is the list of available TOML keys in llmk. See the reference manu
 		* `postprocess` (type: *string*)
 		* `target` (type: *string*, default: `"%S"`)
 * `ps2pdf` (type: *string*, default: `"ps2pdf"`)
-* `sequence` (type: *array of strings*, default: `["latex", "bibtex", "makeindex", "dvipdf"]`)
+* `sequence` (type: *array of strings*, default: `["latex", "bibtex", "makeindex", "makeglossaries", "dvipdf"]`)
 * `source` (type: *string* or *array of strings*, only for `llmk.toml`)
 
 ### Default `programs` table
@@ -215,6 +216,12 @@ aux_empty_size = 9
 [programs.makeindex]
 command = "makeindex"
 target = "%B.idx"
+generated_target = true
+postprocess = "latex"
+
+[programs.makeglossaries]
+command = "makeglossaries"
+target = "%B.glo"
 generated_target = true
 postprocess = "latex"
 

--- a/doc/llmk.tex
+++ b/doc/llmk.tex
@@ -462,6 +462,13 @@ the \ckey{command} key is specified in the \ckey{programs} table, this alias is
 ineffective.
 \end{confkey}
 
+\begin{confkey}{makeglossaries}{type: \type{string}}[default: \code{"makeglossaries"}]
+The command to use for the \progname{makeglossaries} program. Internally, this key
+is an alias for the \ckey{command} key in the \progname{makeglossaries} entry. If
+the \ckey{command} key is specified in the \ckey{programs} table, this alias is
+ineffective.
+\end{confkey}
+
 \begin{confkey}{max\_repeat}{type: \type{integer}}[default: \code{5}]
 You can specify the maximum number of execution repetitions for each command in
 your \ckey{sequence}. When processing your \ckey{sequence}, \prog{llmk} repeats
@@ -661,6 +668,18 @@ generated_target = true
 postprocess = "latex"
 \end{lstlisting}
 
+\Program{makeglossaries} The entry for the Makeglossaries program and friends. The
+\progname{latex} program is set as \ckey{postprocess} so that to make sure
+rerunning {\LaTeX} command after this execution.
+%
+\begin{lstlisting}[style=toml]
+[programs.makeglossaries]
+command = "makeglossaries"
+target = "%B.glo"
+generated_target = true
+postprocess = "latex"
+\end{lstlisting}
+
 \Program{ps2pdf} The entry for the \prog{ps2pdf} program and friends.
 %
 \begin{lstlisting}[style=toml]
@@ -676,7 +695,7 @@ generated_target = true
 The following is the default value for the \ckey{sequence} array:
 %
 \begin{htcode}
-["latex", "bibtex", "makeindex", "dvipdf"]
+["latex", "bibtex", "makeindex", "makeglossaries", "dvipdf"]
 \end{htcode}
 
 With these default settings in the \ckey{programs} table the \ckey{sequence}
@@ -706,7 +725,7 @@ $\text{\progname{dvips}}+\text{\progname{ps2pdf}}$ combination instead of
 \progname{dvipdf}, you can just modify the value of \ckey{sequence} a bit:
 %
 \begin{lstlisting}[style=toml]
-sequence = ["latex", "bibtex", "makeindex", "dvips", "ps2pdf"]
+sequence = ["latex", "bibtex", "makeindex", "makeglossaries", "dvips", "ps2pdf"]
 \end{lstlisting}
 
 \section{Other supported formats}

--- a/llmk.lua
+++ b/llmk.lua
@@ -67,9 +67,10 @@ M.top_level_spec = {
   latex = {'string', 'lualatex'},
   llmk_version = {'string', nil},
   makeindex = {'string', 'makeindex'},
+  makeglossaries = {'string', 'makeglossaries'},
   max_repeat = {'integer', 5},
   ps2pdf = {'string', 'ps2pdf'},
-  sequence = {'[string]', {'latex', 'bibtex', 'makeindex', 'dvipdf'}},
+  sequence = {'[string]', {'latex', 'bibtex', 'makeindex', 'makeglossaries', 'dvipdf'}},
   source = {'*[string]', nil},
 }
 
@@ -110,6 +111,11 @@ M.default_programs = {
   },
   makeindex = {
     target = '%B.idx',
+    generated_target = true,
+    postprocess = 'latex',
+  },
+  makeglossaries = {
+    target = '%B.glo',
     generated_target = true,
     postprocess = 'latex',
   },
@@ -380,7 +386,7 @@ local function update_config(config, tab)
   local config = merge_table(config, tab)
 
   -- set essential program names from top-level
-  local prg_names = {'latex', 'bibtex', 'makeindex', 'dvipdf', 'dvips', 'ps2pdf'}
+  local prg_names = {'latex', 'bibtex', 'makeindex', 'makeglossaries', 'dvipdf', 'dvips', 'ps2pdf'}
   for _, name in pairs(prg_names) do
     config = fetch_from_top_level(config, name)
   end

--- a/spec/dry_run_spec.rb
+++ b/spec/dry_run_spec.rb
@@ -25,11 +25,15 @@ RSpec.describe "With --dry-run, processing example", :type => :aruba do
         Dry running: xelatex -interaction=nonstopmode -file-line-error -synctex=1 "simple.tex"
         Dry running: makeindex "simple.idx"
         Dry running: xelatex -interaction=nonstopmode -file-line-error -synctex=1 "simple.tex"
+        Dry running: makeglossaries "simple.glo"
+        Dry running: xelatex -interaction=nonstopmode -file-line-error -synctex=1 "simple.tex"
         Dry running: dvipdfmx "simple.dvi"
         Dry running: xelatex -interaction=nonstopmode -file-line-error -synctex=1 "default.tex"
         Dry running: bibtex "default"
         Dry running: xelatex -interaction=nonstopmode -file-line-error -synctex=1 "default.tex"
         Dry running: makeindex "default.idx"
+        Dry running: xelatex -interaction=nonstopmode -file-line-error -synctex=1 "default.tex"
+        Dry running: makeglossaries "default.glo"
         Dry running: xelatex -interaction=nonstopmode -file-line-error -synctex=1 "default.tex"
         Dry running: dvipdfmx "default.dvi"
       EXPECTED
@@ -41,12 +45,16 @@ RSpec.describe "With --dry-run, processing example", :type => :aruba do
         llmk info: <-- as postprocess; possibly with rerunning; if the target file "simple.tex" exists
         llmk info: <-- if the target file "simple.idx" has been generated
         llmk info: <-- as postprocess; possibly with rerunning; if the target file "simple.tex" exists
+        llmk info: <-- if the target file "simple.glo" has been generated
+        llmk info: <-- as postprocess; possibly with rerunning; if the target file "simple.tex" exists
         llmk info: <-- if the target file "simple.dvi" has been generated
         llmk info: Beginning a sequence for "default.tex"
         llmk info: <-- possibly with rerunning; if the target file "default.tex" exists
         llmk info: <-- if the target file "default.bib" exists
         llmk info: <-- as postprocess; possibly with rerunning; if the target file "default.tex" exists
         llmk info: <-- if the target file "default.idx" has been generated
+        llmk info: <-- as postprocess; possibly with rerunning; if the target file "default.tex" exists
+        llmk info: <-- if the target file "default.glo" has been generated
         llmk info: <-- as postprocess; possibly with rerunning; if the target file "default.tex" exists
         llmk info: <-- if the target file "default.dvi" has been generated
       EXPECTED


### PR DESCRIPTION
This functions similarly to makeindex. If a `*.glo` file is outputted by latex, then llmk will now run `makeglossaries` to generate a `*.gls` file.