### PR TITLE
Add output_directory option to top-level config

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The following is the list of available TOML keys in llmk. See the reference manu
 * `latex` (type: *string*, default: `"lualatex"`)
 * `llmk_version` (type: *string*)
 * `makeindex` (type: *string*, default: `"makeindex"`)
+* `makeglossaries` (type: *string*, default: `"makeglossaries"`)
 * `max_repeat` (type: *integer*, default: `5`)
 * `programs` (type: *table*)
 	* \<program name\>
@@ -182,7 +183,7 @@ The following is the list of available TOML keys in llmk. See the reference manu
 		* `postprocess` (type: *string*)
 		* `target` (type: *string*, default: `"%S"`)
 * `ps2pdf` (type: *string*, default: `"ps2pdf"`)
-* `sequence` (type: *array of strings*, default: `["latex", "bibtex", "makeindex", "dvipdf"]`)
+* `sequence` (type: *array of strings*, default: `["latex", "bibtex", "makeindex", "makeglossaries", "dvipdf"]`)
 * `source` (type: *string* or *array of strings*, only for `llmk.toml`)
 
 ### Default `programs` table
@@ -215,6 +216,12 @@ aux_empty_size = 9
 [programs.makeindex]
 command = "makeindex"
 target = "%B.idx"
+generated_target = true
+postprocess = "latex"
+
+[programs.makeglossaries]
+command = "makeglossaries"
+target = "%B.glo"
 generated_target = true
 postprocess = "latex"
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ In the `args` keys in each program, some format specifiers are available. Those 
 
 * `%S`: the file name given to llmk as an argument (source)
 * `%T`: the target for each program
-* `%B`: the base name of `%S`
+* `%o`: the output directory, or `.` if none was specified
+* `%b`: the base name of `%S`
+* `%B`: the output directory concatenated with the base name of `%S`
 
 This way is a bit complicated but strong enough allowing you to use any kind of outer programs.
 
@@ -172,6 +174,7 @@ The following is the list of available TOML keys in llmk. See the reference manu
 * `makeindex` (type: *string*, default: `"makeindex"`)
 * `makeglossaries` (type: *string*, default: `"makeglossaries"`)
 * `max_repeat` (type: *integer*, default: `5`)
+* `output_directory` (type: *string*)
 * `programs` (type: *table*)
 	* \<program name\>
 		* `args` (type: *string* or *array of strings*, default: `["%T"]`)

--- a/doc/llmk.tex
+++ b/doc/llmk.tex
@@ -462,6 +462,13 @@ the \ckey{command} key is specified in the \ckey{programs} table, this alias is
 ineffective.
 \end{confkey}
 
+\begin{confkey}{makeglossaries}{type: \type{string}}[default: \code{"makeglossaries"}]
+The command to use for the \progname{makeglossaries} program. Internally, this key
+is an alias for the \ckey{command} key in the \progname{makeglossaries} entry. If
+the \ckey{command} key is specified in the \ckey{programs} table, this alias is
+ineffective.
+\end{confkey}
+
 \begin{confkey}{max\_repeat}{type: \type{integer}}[default: \code{5}]
 You can specify the maximum number of execution repetitions for each command in
 your \ckey{sequence}. When processing your \ckey{sequence}, \prog{llmk} repeats
@@ -661,6 +668,18 @@ generated_target = true
 postprocess = "latex"
 \end{lstlisting}
 
+\Program{makeglossaries} The entry for the Makeglossaries program and friends. The
+\progname{latex} program is set as \ckey{postprocess} so that to make sure
+rerunning {\LaTeX} command after this execution.
+%
+\begin{lstlisting}[style=toml]
+[programs.makeglossaries]
+command = "makeglossaries"
+target = "%B.glo"
+generated_target = true
+postprocess = "latex"
+\end{lstlisting}
+
 \Program{ps2pdf} The entry for the \prog{ps2pdf} program and friends.
 %
 \begin{lstlisting}[style=toml]
@@ -676,7 +695,7 @@ generated_target = true
 The following is the default value for the \ckey{sequence} array:
 %
 \begin{htcode}
-["latex", "bibtex", "makeindex", "dvipdf"]
+["latex", "bibtex", "makeindex", "makeglossaries", "dvipdf"]
 \end{htcode}
 
 With these default settings in the \ckey{programs} table the \ckey{sequence}
@@ -706,7 +725,7 @@ $\text{\progname{dvips}}+\text{\progname{ps2pdf}}$ combination instead of
 \progname{dvipdf}, you can just modify the value of \ckey{sequence} a bit:
 %
 \begin{lstlisting}[style=toml]
-sequence = ["latex", "bibtex", "makeindex", "dvips", "ps2pdf"]
+sequence = ["latex", "bibtex", "makeindex", "makeglossaries", "dvips", "ps2pdf"]
 \end{lstlisting}
 
 \section{Other supported formats}

--- a/doc/llmk.tex
+++ b/doc/llmk.tex
@@ -368,8 +368,12 @@ executing actions by \prog{llmk}:
   argument or as an element of the \ckey{source} array.
 \item |%T|
   is replaced by the target for each program.
-\item |%B|
+\item |%o|
+  is replaced by the output directory, or \code{.} if none was specified.
+\item |%b|
   is replaced by the basename of |%S|.
+\item |%B|
+  is replaced by the output directory concatenated with the basename of |%S|.
 \end{itemize}
 
 Some keys have default values; the default configuration of \prog{llmk} should
@@ -475,6 +479,10 @@ your \ckey{sequence}. When processing your \ckey{sequence}, \prog{llmk} repeats
 a command until \ckey{aux\_file} becomes unchanged from the former execution if
 the key is specified and the corresponding auxiliary file exists. This key is to
 prevent the potential infinite loop of repetition.
+\end{confkey}
+
+\begin{confkey}{output\_directory}{type: \type{string}}[default: \code{nil}]
+Use this option to specify a directory where \progname{latex} output files should be written to and read from. This directory must already exist, or else \prog{llmk} will fail with an error. If the option is not specified, then output files will be written to the directory where \prog{llmk} is run from.
 \end{confkey}
 
 \begin{confkey}{programs}{type: \type{table}}

--- a/llmk.lua
+++ b/llmk.lua
@@ -67,9 +67,10 @@ M.top_level_spec = {
   latex = {'string', 'lualatex'},
   llmk_version = {'string', nil},
   makeindex = {'string', 'makeindex'},
+  makeglossaries = {'string', 'makeglossaries'},
   max_repeat = {'integer', 5},
   ps2pdf = {'string', 'ps2pdf'},
-  sequence = {'[string]', {'latex', 'bibtex', 'makeindex', 'dvipdf'}},
+  sequence = {'[string]', {'latex', 'bibtex', 'makeindex', 'makeglossaries', 'dvipdf'}},
   source = {'*[string]', nil},
 }
 
@@ -110,6 +111,11 @@ M.default_programs = {
   },
   makeindex = {
     target = '%B.idx',
+    generated_target = true,
+    postprocess = 'latex',
+  },
+  makeglossaries = {
+    target = '%B.glo',
     generated_target = true,
     postprocess = 'latex',
   },
@@ -380,7 +386,7 @@ local function update_config(config, tab)
   local config = merge_table(config, tab)
 
   -- set essential program names from top-level
-  local prg_names = {'latex', 'bibtex', 'makeindex', 'dvipdf', 'dvips', 'ps2pdf'}
+  local prg_names = {'latex', 'bibtex', 'makeindex', 'makeglossaries', 'dvipdf', 'dvips', 'ps2pdf'}
   for _, name in pairs(prg_names) do
     config = fetch_from_top_level(config, name)
   end


### PR DESCRIPTION
This PR should be reviewed and merged after #14 (Support for `makeglossaries`)

The PR adds support for an `output_directory` option in top-level config. This is passed to latex via the `-output-directory` option. Other commands, such as `make_index`, need the output directory path to be prepended to the basename.

The `%B` directive was been changed to a concatenation of the output directory and the basename, in the case that an output directory was provided, in order to facilitate this. The `%b` directive was added to produce the same behavior as `%B` did previously. The `%o` directive was added to insert the output directory path itself, or `.` in the case that no output directory was provided.

The `makeglossaries` command required that llmk be able to distinguish between a target path as provided to the command, and the true target path, so that llmk can check if the target file exists or has been updated. This is important because the directory containing `*.glo` and `*.ist` files must be provided to `makeglossaries` via the `-d` option; simply concatenating the output directory and the `*.glo` target path will not work. To achieve this, the `target_path` attribute has been added to program objects. This allows the actual target path to be provided to llmk as a distinct value from the target path provided as the final argument to a `makeglossaries` command.