### PR TITLE
Override Source Entry on llmk.toml from a New Command Line Argument

### DIFF
--- a/doc/llmk.1.md
+++ b/doc/llmk.1.md
@@ -28,6 +28,11 @@ If one or more FILE(s) are specified, `llmk` reads the TOML fields or other supp
   Suppress warnings and most error messages.
 * `-s`, `--silent`:
   Silence messages from called programs.
+* `--source`:
+  Substitute the given path for the `source` entry in `llmk.toml` at runtime.
+  This is a temporary feature and is prohibited by default unless explicitly enabled.
+* `-T`, `--temporary`:
+  Allow temporary features.
 * `-v`, `--verbose`:
   Print additional information (e.g., running commands).
 * `-V`, `--version`:

--- a/doc/llmk.tex
+++ b/doc/llmk.tex
@@ -182,6 +182,16 @@ successfully. When this is specified, all other options and arguments are
 ignored.
 \end{clopt}
 
+\begin{clopt}{\lopt{source}}
+Substitutes the given argument value for the \code{source} entry in
+\code{llmk.toml} at runtime. This is useful when you want to build an
+alternative source file instead of the one specified in \code{llmk.toml},
+while keeping the rest of configuration unchanged. This option must be
+used with \sopt{T} or \lopt{temporary} since this is a temporary
+feature. Refer to Section \ref{sec:temporary_features} for more details
+about temporary features.
+\end{clopt}
+
 \begin{clopt}{\sopt{n}, \lopt{dry-run}}
 Show what would have been executed without actually invoking the commands. This
 flag is useful if you want to make sure whether your configuration will work as
@@ -191,6 +201,11 @@ further detailed information.
 
 \begin{clopt}{\sopt{q}, \lopt{quiet}}
 This suppress most of the messages from the program.
+\end{clopt}
+
+\begin{clopt}{\sopt{T}, \lopt{temporary}}
+Allows temporary features. Refer to Section \ref{sec:temporary_features}
+for more details.
 \end{clopt}
 
 \begin{clopt}{\sopt{s}, \lopt{silent}}
@@ -867,6 +882,16 @@ For example, the following two configuration are equivalent:\\
 \documentclass{article}
 \end{lstlisting}
 \end{minipage}
+
+\section{Temporary Features}
+\label{sec:temporary_features}
+\prog{llmk} provides some features, temporary features, that are
+useful but should not be used regularly. These features may break the
+consistency of workflow definition files therefore should be limited
+to temporary use. The temporary features are prohibited unless the
+command-line option \sopt{T} or \lopt{temporary} is specified. For
+example, \lopt{source} must be used with \lopt{temporary}; otherwise
+\prog{llmk} raises an error.
 
 \section{Acknowledgements}
 

--- a/examples/overridesource.tex
+++ b/examples/overridesource.tex
@@ -1,0 +1,9 @@
+% This is an example LaTeX document for llmk.
+% Public domain.
+
+\documentclass{article}
+\begin{document}
+
+Great to see you again, \textsf{llmk}!
+
+\end{document}

--- a/spec/examples_spec.rb
+++ b/spec/examples_spec.rb
@@ -156,4 +156,60 @@ RSpec.describe "Processing example", :type => :aruba do
       expect(last_command_started).to be_successfully_executed
     end
   end
+
+  context "overridesource.tex" do
+    before(:each) { use_example "llmk.toml", "overridesource.tex" }
+    before(:each) { run_llmk "-v", "-T", "--source=overridesource.tex" }
+
+    it "should produce overridesource.pdf" do
+      expect(stderr).to include(info_line_seq 'overridesource.tex')
+      expect(stderr).to include(info_line_runcmd 'xelatex', 'overridesource.tex')
+
+      expect(file?('overridesource.pdf')).to be true
+
+      expect(last_command_started).to be_successfully_executed
+    end
+  end
+
+  context "overridesource.tex" do
+    before(:each) { use_example "llmk.toml", "overridesource.tex" }
+    before(:each) { run_llmk "-v", "--temporary", "--source=overridesource.tex" }
+
+    it "should produce overridesource.pdf" do
+      expect(stderr).to include(info_line_seq 'overridesource.tex')
+      expect(stderr).to include(info_line_runcmd 'xelatex', 'overridesource.tex')
+
+      expect(file?('overridesource.pdf')).to be true
+
+      expect(last_command_started).to be_successfully_executed
+    end
+  end
+
+  context "overridesource.tex" do
+    before(:each) { use_example "llmk.toml", "overridesource.tex" }
+    before(:each) { run_llmk "-v", "--source=overridesource.tex" }
+
+    it "should fail due to a missing --temporary flag" do
+      expect(stderr).to include("Some options enable non-reproducible behavior and require the --temporary flag. See the manual for details.")
+
+      expect(file?('overridesource.pdf')).to be false
+
+      expect(last_command_started).not_to be_successfully_executed
+    end
+  end
+
+  context "default.tex" do
+    before(:each) { use_example "default.tex" }
+    before(:each) { run_llmk "-v", "-T", "default.tex" }
+
+    it "should produce default.pdf even when --temporary is given alone" do
+      expect(stderr).to include(info_line_seq 'default.tex')
+      expect(stderr).to include(info_line_runcmd 'lualatex', 'default.tex')
+
+      expect(file?('default.pdf')).to be true
+
+      expect(last_command_started).to be_successfully_executed
+    end
+  end
+
 end

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "Showing help", :type => :aruba do
         -n, --dry-run         Show what would have been executed.
         -q, --quiet           Suppress most messages.
         -s, --silent          Silence messages from called programs.
+        --source              Substitute the given path for the `source` entry on
+                              `llmk.toml` at runtime.  This is a temporary
+                              feature and is prohibited by default.
+        -T, --temporary       Allow the temporary features.
         -v, --verbose         Print additional information.
         -V, --version         Print the version number.
 


### PR DESCRIPTION
Closes #25 

This PR adds a new command line argument `-i`, `--source` that overrides `source` entry on llmk.toml.
